### PR TITLE
Add indent to Zuul YAML route

### DIFF
--- a/zuulsvr/src/main/resources/application.yml
+++ b/zuulsvr/src/main/resources/application.yml
@@ -20,4 +20,4 @@ eureka:
 zuul:
   prefix:  /api
   routes:
-  organizationservice: /organization/**
+    organizationservice: /organization/**


### PR DESCRIPTION
My Zuul server didn't start. Debugging showed the issue to be with the YAML route configuration.

PS - excellent book.